### PR TITLE
Fixed flux image mashups using wrong strengths 

### DIFF
--- a/src/image_gen/sd_workflows.py
+++ b/src/image_gen/sd_workflows.py
@@ -236,7 +236,7 @@ class FluxWorkflow(SDWorkflow):
         style_model = StyleModelLoader(StyleModels.flux1_redux_dev)
 
         for i, input in enumerate(image_input):
-            mashup_strength = params.mashup_image_strength if i == 0 else params.mashup_inputimage_strength
+            mashup_strength = params.mashup_inputimage_strength if i == 0 else params.mashup_image_strength
             if input is None:
                 continue
 


### PR DESCRIPTION
In flux image mashups, the mashup_image_strength was being applied to the input_image instead of the mashup_image, and mashup_inputimage_strength was being applied to mashup_image.