### PR TITLE
SDXL/Pony Text Encoder call bugfix

### DIFF
--- a/src/image_gen/sd_workflows.py
+++ b/src/image_gen/sd_workflows.py
@@ -106,7 +106,7 @@ class SD15Workflow(SDWorkflow):
 
 class SDXLWorkflow(SDWorkflow):
     def condition_prompts(self, positive_prompt: str, negative_prompt: str):
-        self.conditioning = CLIPTextEncodeSDXL(4096, 4096, 0, 0, 4096, 4096, positive_prompt, self.clip, positive_prompt)
+        self.conditioning = CLIPTextEncodeSDXL(self.clip, 4096, 4096, 0, 0, 4096, 4096, positive_prompt, positive_prompt)
         self.negative_conditioning = CLIPTextEncode(negative_prompt, self.clip)
 
     def condition_for_detailing(self, controlnet_name, image):
@@ -121,7 +121,7 @@ class SDXLWorkflow(SDWorkflow):
 
 class PonyWorkflow(SDXLWorkflow):
     def condition_prompts(self, positive_prompt: str, negative_prompt: str):
-        self.conditioning = CLIPTextEncodeSDXL(1024, 1024, 0, 0, 1024, 1024, positive_prompt, self.clip, positive_prompt)
+        self.conditioning = CLIPTextEncodeSDXL(self.clip, 1024, 1024, 0, 0, 1024, 1024, positive_prompt, positive_prompt)
         self.negative_conditioning = CLIPTextEncode(negative_prompt, self.clip)
 
 class SDCascadeWorkflow(SDWorkflow):


### PR DESCRIPTION
Changed the parameters in the method call for CLIPTextEncodeSDXL for SDXL and Pony so that they fit a method signature change in ComfyUI.