### PR TITLE
Fix file encoding issues on Windows

### DIFF
--- a/src/audio_gen/audio_gen.py
+++ b/src/audio_gen/audio_gen.py
@@ -14,7 +14,7 @@ load(get_server_address())
 from comfy_script.runtime.nodes import *
 
 config = configparser.ConfigParser()
-config.read("config.properties")
+config.read("config.properties", encoding="utf8")
 server_address = config["LOCAL"]["SERVER_ADDRESS"]
 
 

--- a/src/comfy_client.py
+++ b/src/comfy_client.py
@@ -4,7 +4,7 @@ import subprocess
 
 def run_comfy_client():
     config = configparser.ConfigParser()
-    config.read("config.properties")
+    config.read("config.properties", encoding='utf8')
 
     if config["BOT"]["USE_EMBEDDED_COMFY"].lower() == "true":
         import os

--- a/src/comfy_workflows.py
+++ b/src/comfy_workflows.py
@@ -22,7 +22,7 @@ model_type_to_workflow = {
 }
 
 config = configparser.ConfigParser()
-config.read("config.properties")
+config.read("config.properties", encoding="utf8")
 comfy_root_directory = config["LOCAL"]["COMFY_ROOT_DIR"]
 use_align_your_steps = config["VIDEO_GENERATION_DEFAULTS"]["USE_ALIGN_YOUR_STEPS"].lower()
 image_wan_teacache = config["IMAGE_WAN_GENERATION_DEFAULTS"]["USE_TEACACHE"].lower()

--- a/src/defaults.py
+++ b/src/defaults.py
@@ -3,7 +3,7 @@ import configparser
 from src.image_gen.ImageWorkflow import *
 
 config = configparser.ConfigParser()
-config.read("config.properties")
+config.read("config.properties", encoding="utf8")
 
 def get_default_from_config(section : str, option : str, default = None) -> str:
     if section not in config:

--- a/src/util.py
+++ b/src/util.py
@@ -7,7 +7,7 @@ from src.image_gen import ImageWorkflow
 
 def read_config():
     config = configparser.ConfigParser()
-    config.read("config.properties")
+    config.read("config.properties", encoding='utf8')
     return config
 
 
@@ -115,7 +115,7 @@ async def process_attachment(attachment: Attachment, interaction: Interaction):
 def get_server_address():
     import configparser
     config = configparser.ConfigParser()
-    config.read("config.properties")
+    config.read("config.properties", encoding="utf8")
 
     if config["BOT"]["USE_EMBEDDED_COMFY"].lower() == "true":
         return f"http://localhost:{config['EMBEDDED']['SERVER_PORT']}"


### PR DESCRIPTION
Force utf8 to prevent Python on Windows from using cp1252 encoding. I believe this error came about by adding the Chinese characters to server.properties, which cp1252 doesn't support